### PR TITLE
ci: Add forks build support to Build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  pull_request_target:
+    branches: [ main ]
 
 jobs:
   static-analysis:


### PR DESCRIPTION
Uses: 
https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target

This may be a bad idea...
https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

Probably best to get `pull_request` working which means no secrets are available...

