### PR TITLE
Get Children Blocks 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
 use crate::models::search::{DatabaseQuery, SearchRequest};
-use crate::models::{Database, DatabaseId, ListResponse, Object, Page};
+use crate::models::{Database, DatabaseId, ListResponse, Object, Page, Block};
 use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::{header, Client, ClientBuilder, RequestBuilder};
 use serde::de::DeserializeOwned;
 
-mod models;
+pub mod models;
 
 const NOTION_API_VERSION: &'static str = "2021-05-13";
 
@@ -102,6 +102,18 @@ impl NotionApi {
                 .json(&query.into()),
         )
         .await?)
+    }
+
+    pub async fn get_block_children<T: Identifiable>(
+        &self,
+        block_id: T
+    ) -> Result<ListResponse<Block>, NotionApiClientError> {
+        Ok(NotionApi::make_json_request(
+            self.client.get(&format!(
+                "https://api.notion.com/v1/blocks/{block_id}/children",
+                block_id = block_id.id().
+            ))
+        ).await?)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,14 +104,14 @@ impl NotionApi {
         .await?)
     }
 
-    pub async fn get_block_children<T: Identifiable>(
+    pub async fn get_block_children<T: Identifiable<Type = String>>(
         &self,
         block_id: T
     ) -> Result<ListResponse<Block>, NotionApiClientError> {
         Ok(NotionApi::make_json_request(
             self.client.get(&format!(
                 "https://api.notion.com/v1/blocks/{block_id}/children",
-                block_id = block_id.id().
+                block_id = block_id.id().id()
             ))
         ).await?)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ impl NotionApi {
         Ok(NotionApi::make_json_request(
             self.client.get(&format!(
                 "https://api.notion.com/v1/blocks/{block_id}/children",
-                block_id = block_id.id().id()
+                block_id = block_id.id()
             ))
         ).await?)
     }
@@ -123,8 +123,8 @@ mod tests {
     use crate::models::search::{
         DatabaseQuery, FilterCondition, FilterProperty, FilterValue, NotionSearch, TextCondition,
     };
-    use crate::models::Object;
-    use crate::NotionApi;
+    use crate::models::{Object, BlockId};
+    use crate::{NotionApi, Identifiable};
 
     fn test_token() -> String {
         let token = {
@@ -225,19 +225,14 @@ mod tests {
             })
             .await?;
 
-        for page in search_response.results() {
-            let response = api
-                .get_block_children(page)
-                .await?;
+        println!("{:?}", search_response.results.len());
+
+        for object in search_response.results {
+            let _block = match object {
+                Object::Page { page } => api.get_block_children(BlockId::from(page.id())).await.unwrap(),
+                _ => panic!("Should not have received anything but pages!")
+            };
         }
-
-
-        // let db = response.results()[0].clone();
-        //
-        // // todo: fix this clone issue
-        // let db_result = api.get_database(db.clone()).await?;
-        //
-        // assert_eq!(db, db_result);
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 use crate::models::search::{DatabaseQuery, SearchRequest};
-use crate::models::{Database, DatabaseId, ListResponse, Object, Page, Block};
+use crate::models::{Database, DatabaseId, ListResponse, Object, Page, Block, BlockId};
 use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::{header, Client, ClientBuilder, RequestBuilder};
 use serde::de::DeserializeOwned;
@@ -104,7 +104,7 @@ impl NotionApi {
         .await?)
     }
 
-    pub async fn get_block_children<T: Identifiable<Type = String>>(
+    pub async fn get_block_children<T: Identifiable<Type = BlockId>>(
         &self,
         block_id: T
     ) -> Result<ListResponse<Block>, NotionApiClientError> {
@@ -210,6 +210,34 @@ mod tests {
         let db_result = api.get_database(db.clone()).await?;
 
         assert_eq!(db, db_result);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn get_block_children() -> Result<(), Box<dyn std::error::Error>> {
+        let api = test_client();
+
+        let search_response = api
+            .search(NotionSearch::Filter {
+                value: FilterValue::Page,
+                property: FilterProperty::Object,
+            })
+            .await?;
+
+        for page in search_response.results() {
+            let response = api
+                .get_block_children(page)
+                .await?;
+        }
+
+
+        // let db = response.results()[0].clone();
+        //
+        // // todo: fix this clone issue
+        // let db_result = api.get_database(db.clone()).await?;
+        //
+        // assert_eq!(db, db_result);
 
         Ok(())
     }

--- a/src/models.rs
+++ b/src/models.rs
@@ -168,17 +168,38 @@ impl Display for BlockId {
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+#[serde(rename_all = "snake_case")]
+pub enum BlockType {
+    Paragraph,
+    Heading1,
+    Heading2,
+    Heading3,
+    BulletedListItem,
+    NumberedListItem,
+    ToDo,
+    Toggle,
+    ChildPage,
+    Unsupported
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct Block {
     id: BlockId,
+    r#type: BlockType,
     created_time: DateTime<Utc>,
     last_edited_time: DateTime<Utc>,
     has_children: bool,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
+
+#[derive(Eq, Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(tag = "object")]
 #[serde(rename_all = "snake_case")]
 pub enum Object {
+    Block {
+        #[serde(flatten)]
+        block: Block
+    },
     Database {
         #[serde(flatten)]
         database: Database,
@@ -195,7 +216,6 @@ pub enum Object {
         #[serde(flatten)]
         user: User,
     },
-    Block {},
 }
 
 impl Object {

--- a/src/models.rs
+++ b/src/models.rs
@@ -135,38 +135,6 @@ pub struct Page {
     parent: Parent,
 }
 
-impl Identifiable for String {
-    type Type = String;
-
-    fn id(&self) -> &Self::Type {
-        self
-    }
-}
-
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Hash, Clone)]
-#[serde(transparent)]
-pub struct BlockId(String);
-
-impl BlockId {
-    pub fn id(&self) -> &str {
-        &self.0
-    }
-}
-
-impl Identifiable for BlockId {
-    type Type = BlockId;
-
-    fn id(&self) -> &Self::Type {
-        self
-    }
-}
-
-impl Display for BlockId {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum BlockType {
@@ -268,6 +236,34 @@ pub enum Block {
     Unsupported {}
 }
 
+impl Identifiable for Block {
+    type Type = BlockId;
+
+    fn id(&self) -> &Self::Type {
+        match self {
+            Block::Paragraph { common, paragraph: _ } => &common.id,
+            Block::Heading1 { common, heading_1: _} => &common.id,
+            Block::Heading2 { common, heading_2: _} => &common.id,
+            Block::Heading3 { common, heading_3: _} => &common.id,
+            Block::BulletedListItem { common, bulleted_list_item: _} => &common.id,
+            Block::NumberedListItem { common, numbered_list_item: _} => &common.id,
+            Block::ToDo { common, to_do: _ } => &common.id,
+            Block::Toggle { common, toggle: _} => &common.id,
+            Block::ChildPage { common, child_page: _} => &common.id,
+            Block::Unsupported {} => { panic!("Trying to reference identifier for unsupported block!") }
+        }
+
+    }
+}
+
+impl Identifiable for Page {
+    type Type = PageId;
+
+    fn id(&self) -> &Self::Type {
+        &self.id
+    }
+}
+
 #[derive(Eq, Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(tag = "object")]
 #[serde(rename_all = "snake_case")]
@@ -292,6 +288,34 @@ pub enum Object {
         #[serde(flatten)]
         user: User,
     },
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Hash, Clone)]
+#[serde(transparent)]
+pub struct BlockId(String);
+
+impl BlockId {
+    pub fn id(&self) -> &str {
+        &self.0
+    }
+
+    pub fn from(page_id: &PageId) -> Self {
+        BlockId(page_id.clone().0)
+    }
+}
+
+impl Identifiable for BlockId {
+    type Type = BlockId;
+
+    fn id(&self) -> &Self::Type {
+        self
+    }
+}
+
+impl Display for BlockId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
 }
 
 impl Object {

--- a/src/models.rs
+++ b/src/models.rs
@@ -183,14 +183,90 @@ pub enum BlockType {
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
-pub struct Block {
+pub struct BlockCommon {
     id: BlockId,
-    r#type: BlockType,
     created_time: DateTime<Utc>,
     last_edited_time: DateTime<Utc>,
     has_children: bool,
 }
 
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+pub struct TextAndChildren {
+    text: Vec<RichText>,
+    children: Option<Vec<Block>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+pub struct Text {
+    text: Vec<RichText>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+pub struct ToDoFields {
+    text: Vec<RichText>,
+    checked: bool,
+    children: Option<Vec<Block>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+pub struct ChildPageFields {
+    title: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+#[serde(tag = "type")]
+#[serde(rename_all = "snake_case")]
+pub enum Block {
+    Paragraph {
+        #[serde(flatten)]
+        common: BlockCommon,
+        paragraph: TextAndChildren
+    },
+    #[serde(rename="heading_1")]
+    Heading1 {
+        #[serde(flatten)]
+        common: BlockCommon,
+        heading_1: Text,
+    },
+    #[serde(rename="heading_2")]
+    Heading2 {
+        #[serde(flatten)]
+        common: BlockCommon,
+        heading_2: Text,
+    },
+    #[serde(rename="heading_3")]
+    Heading3 {
+        #[serde(flatten)]
+        common: BlockCommon,
+        heading_3: Text,
+    },
+    BulletedListItem {
+        #[serde(flatten)]
+        common: BlockCommon,
+        bulleted_list_item: TextAndChildren,
+    },
+    NumberedListItem {
+        #[serde(flatten)]
+        common: BlockCommon,
+        numbered_list_item: TextAndChildren,
+    },
+    ToDo {
+        #[serde(flatten)]
+        common: BlockCommon,
+        to_do: ToDoFields,
+    },
+    Toggle {
+        #[serde(flatten)]
+        common: BlockCommon,
+        toggle: TextAndChildren,
+    },
+    ChildPage {
+        #[serde(flatten)]
+        common: BlockCommon,
+        child_page: ChildPageFields,
+    },
+    Unsupported {}
+}
 
 #[derive(Eq, Serialize, Deserialize, Clone, Debug, PartialEq)]
 #[serde(tag = "object")]

--- a/src/models.rs
+++ b/src/models.rs
@@ -136,21 +136,6 @@ pub struct Page {
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
-#[serde(rename_all = "snake_case")]
-pub enum BlockType {
-    Paragraph,
-    Heading1,
-    Heading2,
-    Heading3,
-    BulletedListItem,
-    NumberedListItem,
-    ToDo,
-    Toggle,
-    ChildPage,
-    Unsupported,
-}
-
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct BlockCommon {
     id: BlockId,
     created_time: DateTime<Utc>,
@@ -233,7 +218,8 @@ pub enum Block {
         common: BlockCommon,
         child_page: ChildPageFields,
     },
-    Unsupported {},
+    #[serde(other)]
+    Unsupported,
 }
 
 impl Identifiable for Block {
@@ -241,36 +227,15 @@ impl Identifiable for Block {
 
     fn id(&self) -> &Self::Type {
         match self {
-            Block::Paragraph {
-                common,
-                paragraph: _,
-            } => &common.id,
-            Block::Heading1 {
-                common,
-                heading_1: _,
-            } => &common.id,
-            Block::Heading2 {
-                common,
-                heading_2: _,
-            } => &common.id,
-            Block::Heading3 {
-                common,
-                heading_3: _,
-            } => &common.id,
-            Block::BulletedListItem {
-                common,
-                bulleted_list_item: _,
-            } => &common.id,
-            Block::NumberedListItem {
-                common,
-                numbered_list_item: _,
-            } => &common.id,
-            Block::ToDo { common, to_do: _ } => &common.id,
-            Block::Toggle { common, toggle: _ } => &common.id,
-            Block::ChildPage {
-                common,
-                child_page: _,
-            } => &common.id,
+            Block::Paragraph { common, .. }
+            | Block::Heading1 { common, .. }
+            | Block::Heading2 { common, .. }
+            | Block::Heading3 { common, .. }
+            | Block::BulletedListItem { common, .. }
+            | Block::NumberedListItem { common, .. }
+            | Block::ToDo { common, .. }
+            | Block::Toggle { common, .. }
+            | Block::ChildPage { common, .. } => &common.id,
             Block::Unsupported {} => {
                 panic!("Trying to reference identifier for unsupported block!")
             }

--- a/src/models.rs
+++ b/src/models.rs
@@ -135,8 +135,45 @@ pub struct Page {
     parent: Parent,
 }
 
+impl Identifiable for String {
+    type Type = String;
+
+    fn id(&self) -> &Self::Type {
+        self
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Hash, Clone)]
+#[serde(transparent)]
+pub struct BlockId(String);
+
+impl BlockId {
+    pub fn id(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Identifiable for BlockId {
+    type Type = BlockId;
+
+    fn id(&self) -> &Self::Type {
+        self
+    }
+}
+
+impl Display for BlockId {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
-pub struct Block {}
+pub struct Block {
+    id: BlockId,
+    created_time: DateTime<Utc>,
+    last_edited_time: DateTime<Utc>,
+    has_children: bool,
+}
 
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 #[serde(tag = "object")]

--- a/src/models.rs
+++ b/src/models.rs
@@ -226,17 +226,18 @@ impl Identifiable for Block {
     type Type = BlockId;
 
     fn id(&self) -> &Self::Type {
+        use Block::*;
         match self {
-            Block::Paragraph { common, .. }
-            | Block::Heading1 { common, .. }
-            | Block::Heading2 { common, .. }
-            | Block::Heading3 { common, .. }
-            | Block::BulletedListItem { common, .. }
-            | Block::NumberedListItem { common, .. }
-            | Block::ToDo { common, .. }
-            | Block::Toggle { common, .. }
-            | Block::ChildPage { common, .. } => &common.id,
-            Block::Unsupported {} => {
+            Paragraph { common, .. }
+            | Heading1 { common, .. }
+            | Heading2 { common, .. }
+            | Heading3 { common, .. }
+            | BulletedListItem { common, .. }
+            | NumberedListItem { common, .. }
+            | ToDo { common, .. }
+            | Toggle { common, .. }
+            | ChildPage { common, .. } => &common.id,
+            Unsupported {} => {
                 panic!("Trying to reference identifier for unsupported block!")
             }
         }

--- a/src/models.rs
+++ b/src/models.rs
@@ -147,7 +147,7 @@ pub enum BlockType {
     ToDo,
     Toggle,
     ChildPage,
-    Unsupported
+    Unsupported,
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
@@ -188,21 +188,21 @@ pub enum Block {
     Paragraph {
         #[serde(flatten)]
         common: BlockCommon,
-        paragraph: TextAndChildren
+        paragraph: TextAndChildren,
     },
-    #[serde(rename="heading_1")]
+    #[serde(rename = "heading_1")]
     Heading1 {
         #[serde(flatten)]
         common: BlockCommon,
         heading_1: Text,
     },
-    #[serde(rename="heading_2")]
+    #[serde(rename = "heading_2")]
     Heading2 {
         #[serde(flatten)]
         common: BlockCommon,
         heading_2: Text,
     },
-    #[serde(rename="heading_3")]
+    #[serde(rename = "heading_3")]
     Heading3 {
         #[serde(flatten)]
         common: BlockCommon,
@@ -233,7 +233,7 @@ pub enum Block {
         common: BlockCommon,
         child_page: ChildPageFields,
     },
-    Unsupported {}
+    Unsupported {},
 }
 
 impl Identifiable for Block {
@@ -241,18 +241,40 @@ impl Identifiable for Block {
 
     fn id(&self) -> &Self::Type {
         match self {
-            Block::Paragraph { common, paragraph: _ } => &common.id,
-            Block::Heading1 { common, heading_1: _} => &common.id,
-            Block::Heading2 { common, heading_2: _} => &common.id,
-            Block::Heading3 { common, heading_3: _} => &common.id,
-            Block::BulletedListItem { common, bulleted_list_item: _} => &common.id,
-            Block::NumberedListItem { common, numbered_list_item: _} => &common.id,
+            Block::Paragraph {
+                common,
+                paragraph: _,
+            } => &common.id,
+            Block::Heading1 {
+                common,
+                heading_1: _,
+            } => &common.id,
+            Block::Heading2 {
+                common,
+                heading_2: _,
+            } => &common.id,
+            Block::Heading3 {
+                common,
+                heading_3: _,
+            } => &common.id,
+            Block::BulletedListItem {
+                common,
+                bulleted_list_item: _,
+            } => &common.id,
+            Block::NumberedListItem {
+                common,
+                numbered_list_item: _,
+            } => &common.id,
             Block::ToDo { common, to_do: _ } => &common.id,
-            Block::Toggle { common, toggle: _} => &common.id,
-            Block::ChildPage { common, child_page: _} => &common.id,
-            Block::Unsupported {} => { panic!("Trying to reference identifier for unsupported block!") }
+            Block::Toggle { common, toggle: _ } => &common.id,
+            Block::ChildPage {
+                common,
+                child_page: _,
+            } => &common.id,
+            Block::Unsupported {} => {
+                panic!("Trying to reference identifier for unsupported block!")
+            }
         }
-
     }
 }
 
@@ -270,7 +292,7 @@ impl Identifiable for Page {
 pub enum Object {
     Block {
         #[serde(flatten)]
-        block: Block
+        block: Block,
     },
     Database {
         #[serde(flatten)]

--- a/src/models/properties.rs
+++ b/src/models/properties.rs
@@ -157,7 +157,7 @@ pub enum PropertyConfiguration {
     Checkbox { id: PropertyId },
     /// Represents a URL Property
     /// See https://developers.notion.com/reference/database#url-configuration
-    URL { id: PropertyId },
+    Url { id: PropertyId },
     /// Represents a Email Property
     /// See https://developers.notion.com/reference/database#email-configuration
     Email { id: PropertyId },


### PR DESCRIPTION
## Description 

Generic implementation of retrieving block information. I have yet to enumerate different fields for specific Block types. 

Fixed some visibility issues for people using this client externally. 
Fixed an casing issue when deserializing Url types


Recreating PR to be a branch instead of fork. 