### PR TITLE
Example wasn't compling + lib fixes 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ features = ["derive"]
 cargo-husky = "1"
 wiremock = "0.5.2"
 anyhow = "1.0.40"
-clap = "3.0.0-beta.2"
+clap = { version = "3.0.0-rc.0", features = ["derive"] }
 skim = "0.9.4"
 crossbeam-channel = "0.5"
 toml = "0.5.8"

--- a/examples/todo/main.rs
+++ b/examples/todo/main.rs
@@ -1,20 +1,20 @@
 mod commands;
 
 use anyhow::{Context, Result};
-use clap::Clap;
+use clap::Parser;
 use notion::ids::DatabaseId;
 use notion::NotionApi;
 use serde::{Deserialize, Serialize};
 
 // From <https://docs.rs/clap/3.0.0-beta.2/clap/>
-#[derive(Clap)]
+#[derive(Parser, Debug)]
 #[clap(version = "1.0", author = "Jake Swenson")]
 struct Opts {
     #[clap(subcommand)]
     command: SubCommand,
 }
 
-#[derive(Clap)]
+#[derive(Parser, Debug)]
 enum SubCommand {
     /// Configure what database this notion-todo example uses
     Config,

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -1,9 +1,9 @@
 use std::fmt::Display;
+use std::num::ParseIntError;
 
 pub trait Identifier: Display {
     fn value(&self) -> &str;
 }
-
 /// Meant to be a helpful trait allowing anything that can be
 /// identified by the type specified in `ById`.
 pub trait AsIdentifier<ById: Identifier> {
@@ -43,6 +43,14 @@ macro_rules! identifer {
         impl std::fmt::Display for $name {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 self.0.fmt(f)
+            }
+        }
+
+        impl std::str::FromStr for $name {
+            type Err = ParseIntError;
+
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                Ok($name(s.to_string()))
             }
         }
     };

--- a/src/ids.rs
+++ b/src/ids.rs
@@ -1,5 +1,5 @@
 use std::fmt::Display;
-use std::num::ParseIntError;
+use std::fmt::Error;
 
 pub trait Identifier: Display {
     fn value(&self) -> &str;
@@ -47,7 +47,7 @@ macro_rules! identifer {
         }
 
         impl std::str::FromStr for $name {
-            type Err = ParseIntError;
+            type Err = Error;
 
             fn from_str(s: &str) -> Result<Self, Self::Err> {
                 Ok($name(s.to_string()))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ use crate::ids::{BlockId, DatabaseId};
 use crate::models::error::ErrorResponse;
 use crate::models::search::{DatabaseQuery, SearchRequest};
 use crate::models::{Block, Database, ListResponse, Object, Page};
-use ids::AsIdentifier;
+use ids::{AsIdentifier, PageId};
 use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::{header, Client, ClientBuilder, RequestBuilder};
 use tracing::Instrument;
@@ -157,6 +157,24 @@ impl NotionApi {
 
         match result {
             Object::Database { database } => Ok(database),
+            response => Err(Error::UnexpectedResponse { response }),
+        }
+    }
+
+    /// Get a page by [PageId].
+    pub async fn get_page<T: AsIdentifier<PageId>>(
+        &self,
+        page_id: T,
+    ) -> Result<Page, Error> {
+        let result = self
+            .make_json_request(self.client.get(format!(
+                "https://api.notion.com/v1/pages/{}",
+                page_id.as_id()
+            )))
+            .await?;
+
+        match result {
+            Object::Page { page } => Ok(page),
             response => Err(Error::UnexpectedResponse { response }),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,10 +162,7 @@ impl NotionApi {
     }
 
     /// Get a page by [PageId].
-    pub async fn get_page<T: AsIdentifier<PageId>>(
-        &self,
-        page_id: T,
-    ) -> Result<Page, Error> {
+    pub async fn get_page<T: AsIdentifier<PageId>>(&self, page_id: T) -> Result<Page, Error> {
         let result = self
             .make_json_request(self.client.get(format!(
                 "https://api.notion.com/v1/pages/{}",

--- a/src/models/properties.rs
+++ b/src/models/properties.rs
@@ -248,7 +248,6 @@ pub struct FileReference {
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 #[serde(tag = "type")]
-//#[serde(untagged)]
 #[serde(rename_all = "snake_case")]
 pub enum PropertyValue { 
     // <https://developers.notion.com/reference/page#title-property-values>

--- a/src/models/properties.rs
+++ b/src/models/properties.rs
@@ -103,6 +103,7 @@ pub enum RollupFunction {
     Min,
     Max,
     Range,
+    ShowOriginal
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
@@ -247,8 +248,9 @@ pub struct FileReference {
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 #[serde(tag = "type")]
+//#[serde(untagged)]
 #[serde(rename_all = "snake_case")]
-pub enum PropertyValue {
+pub enum PropertyValue { 
     // <https://developers.notion.com/reference/page#title-property-values>
     Title {
         id: PropertyId,
@@ -284,9 +286,10 @@ pub enum PropertyValue {
         formula: FormulaResultValue,
     },
     /// <https://developers.notion.com/reference/page#relation-property-values>
+    /// It is actually an array of relations
     Relation {
         id: PropertyId,
-        relation: RelationValue,
+        relation: Option<Vec<RelationValue>>
     },
     Rollup {
         id: PropertyId,

--- a/src/models/properties.rs
+++ b/src/models/properties.rs
@@ -103,7 +103,7 @@ pub enum RollupFunction {
     Min,
     Max,
     Range,
-    ShowOriginal
+    ShowOriginal,
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
@@ -249,7 +249,7 @@ pub struct FileReference {
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 #[serde(tag = "type")]
 #[serde(rename_all = "snake_case")]
-pub enum PropertyValue { 
+pub enum PropertyValue {
     // <https://developers.notion.com/reference/page#title-property-values>
     Title {
         id: PropertyId,
@@ -288,7 +288,7 @@ pub enum PropertyValue {
     /// It is actually an array of relations
     Relation {
         id: PropertyId,
-        relation: Option<Vec<RelationValue>>
+        relation: Option<Vec<RelationValue>>,
     },
     Rollup {
         id: PropertyId,


### PR DESCRIPTION
Rust newb here,
Example app wasn't working because of the changes in clap.
Library wasn't working too, at least part that was querying database. I also added get_page method which is minimal changes, everything for it was already read :)
I also not found a way how to transfor string into DatabaseId or any other Identifier, so i modified macros a bit by adding FromStr method. Without these changes library is not currently usable.