### PR TITLE
Url property can be null

### DIFF
--- a/src/models/properties.rs
+++ b/src/models/properties.rs
@@ -308,11 +308,11 @@ pub enum PropertyValue {
     },
     Url {
         id: PropertyId,
-        url: String,
+        url: Option<String>,
     },
     Email {
         id: PropertyId,
-        email: Option<String>,
+        email: Option<String>, // This can be null from my experience
     },
     PhoneNumber {
         id: PropertyId,

--- a/src/models/properties.rs
+++ b/src/models/properties.rs
@@ -312,7 +312,7 @@ pub enum PropertyValue {
     },
     Email {
         id: PropertyId,
-        email: Option<String>, // This can be null from my experience
+        email: Option<String>,
     },
     PhoneNumber {
         id: PropertyId,


### PR DESCRIPTION
Hello again :) This is small change that i found is required for my code to work properly. Url property can be returned as null, here is an example json returned by notion:
<img width="472" alt="image" src="https://user-images.githubusercontent.com/416393/146413601-d29d325a-2f61-415b-a85e-b2fdb34ecfb0.png">