### PR TITLE
Add support for code blocks

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -229,6 +229,12 @@ pub struct ChildPageFields {
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+pub struct CodeFields {
+    pub text: Vec<RichText>,
+    pub language: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 #[serde(tag = "type")]
 #[serde(rename_all = "snake_case")]
 pub enum Block {
@@ -280,6 +286,11 @@ pub enum Block {
         common: BlockCommon,
         child_page: ChildPageFields,
     },
+    Code {
+        #[serde(flatten)]
+        common: BlockCommon,
+        code: CodeFields,
+    },
     #[serde(other)]
     Unsupported,
 }
@@ -297,6 +308,7 @@ impl AsIdentifier<BlockId> for Block {
             | ToDo { common, .. }
             | Toggle { common, .. }
             | ChildPage { common, .. } => &common.id,
+            | Code { common, .. } => &common.id,
             Unsupported {} => {
                 panic!("Trying to reference identifier for unsupported block!")
             }

--- a/src/models.rs
+++ b/src/models.rs
@@ -307,7 +307,7 @@ impl AsIdentifier<BlockId> for Block {
             | NumberedListItem { common, .. }
             | ToDo { common, .. }
             | Toggle { common, .. }
-            | ChildPage { common, .. } => &common.id,
+            | ChildPage { common, .. }
             | Code { common, .. } => &common.id,
             Unsupported {} => {
                 panic!("Trying to reference identifier for unsupported block!")


### PR DESCRIPTION
Fairly straightforward copy of what the other code is doing, and works when used on pages with code examples.

`text` is a list of rich text objects, and `language` is an effectively unbounded list of potential languages, so string seemed preferable to an enum.