### PR TITLE
Add create page functionality

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ use crate::models::error::ErrorResponse;
 use crate::models::search::{DatabaseQuery, SearchRequest};
 use crate::models::{Block, Database, ListResponse, Object, Page};
 use ids::{AsIdentifier, PageId};
+use models::PageCreateRequest;
 use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::{header, Client, ClientBuilder, RequestBuilder};
 use tracing::Instrument;
@@ -164,6 +165,22 @@ impl NotionApi {
                 "https://api.notion.com/v1/pages/{}",
                 page_id.as_id()
             )))
+            .await?;
+
+        match result {
+            Object::Page { page } => Ok(page),
+            response => Err(Error::UnexpectedResponse { response }),
+        }
+    }
+
+    /// Creates a new page and return the created page
+    pub async fn create_page<T: Into<PageCreateRequest>>(&self, page: T) -> Result<Page, Error> {
+        let result = self
+            .make_json_request(
+                self.client
+                    .post("https://api.notion.com/v1/pages")
+                    .json(&page.into()),
+            )
             .await?;
 
         match result {

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -180,6 +180,12 @@ impl Properties {
     }
 }
 
+#[derive(Serialize, Debug, Eq, PartialEq)]
+pub struct PageCreateRequest {
+    pub parent: Parent,
+    pub properties: Properties,
+}
+
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct Page {
     pub id: PageId,

--- a/src/models/properties.rs
+++ b/src/models/properties.rs
@@ -190,8 +190,10 @@ pub enum PropertyConfiguration {
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct SelectedValue {
-    pub id: SelectOptionId,
-    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<SelectOptionId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
     pub color: Color,
 }
 

--- a/src/models/search.rs
+++ b/src/models/search.rs
@@ -383,7 +383,10 @@ mod tests {
                 property: "Name".to_string(),
                 condition: RichText(TextCondition::Equals("Test".to_string())),
             })?;
-            assert_eq!(json, json!({"property":"Name","rich_text":{"equals":"Test"}}));
+            assert_eq!(
+                json,
+                json!({"property":"Name","rich_text":{"equals":"Test"}})
+            );
 
             Ok(())
         }

--- a/src/models/search.rs
+++ b/src/models/search.rs
@@ -247,7 +247,7 @@ pub enum FormulaCondition {
 #[derive(Serialize, Debug, Eq, PartialEq, Clone)]
 #[serde(rename_all = "snake_case")]
 pub enum PropertyCondition {
-    Text(TextCondition),
+    RichText(TextCondition),
     Number(NumberCondition),
     Checkbox(CheckboxCondition),
     Select(SelectCondition),
@@ -373,7 +373,7 @@ impl From<NotionSearch> for SearchRequest {
 #[cfg(test)]
 mod tests {
     mod text_filters {
-        use crate::models::search::PropertyCondition::Text;
+        use crate::models::search::PropertyCondition::RichText;
         use crate::models::search::{FilterCondition, TextCondition};
         use serde_json::json;
 
@@ -381,9 +381,9 @@ mod tests {
         fn text_property_equals() -> Result<(), Box<dyn std::error::Error>> {
             let json = serde_json::to_value(&FilterCondition {
                 property: "Name".to_string(),
-                condition: Text(TextCondition::Equals("Test".to_string())),
+                condition: RichText(TextCondition::Equals("Test".to_string())),
             })?;
-            assert_eq!(json, json!({"property":"Name","text":{"equals":"Test"}}));
+            assert_eq!(json, json!({"property":"Name","rich_text":{"equals":"Test"}}));
 
             Ok(())
         }
@@ -392,11 +392,11 @@ mod tests {
         fn text_property_contains() -> Result<(), Box<dyn std::error::Error>> {
             let json = serde_json::to_value(&FilterCondition {
                 property: "Name".to_string(),
-                condition: Text(TextCondition::Contains("Test".to_string())),
+                condition: RichText(TextCondition::Contains("Test".to_string())),
             })?;
             assert_eq!(
                 dbg!(json),
-                json!({"property":"Name","text":{"contains":"Test"}})
+                json!({"property":"Name","rich_text":{"contains":"Test"}})
             );
 
             Ok(())
@@ -406,11 +406,11 @@ mod tests {
         fn text_property_is_empty() -> Result<(), Box<dyn std::error::Error>> {
             let json = serde_json::to_value(&FilterCondition {
                 property: "Name".to_string(),
-                condition: Text(TextCondition::IsEmpty),
+                condition: RichText(TextCondition::IsEmpty),
             })?;
             assert_eq!(
                 dbg!(json),
-                json!({"property":"Name","text":{"is_empty":true}})
+                json!({"property":"Name","rich_text":{"is_empty":true}})
             );
 
             Ok(())
@@ -420,11 +420,11 @@ mod tests {
         fn text_property_is_not_empty() -> Result<(), Box<dyn std::error::Error>> {
             let json = serde_json::to_value(&FilterCondition {
                 property: "Name".to_string(),
-                condition: Text(TextCondition::IsNotEmpty),
+                condition: RichText(TextCondition::IsNotEmpty),
             })?;
             assert_eq!(
                 dbg!(json),
-                json!({"property":"Name","text":{"is_not_empty":true}})
+                json!({"property":"Name","rich_text":{"is_not_empty":true}})
             );
 
             Ok(())

--- a/src/models/text.rs
+++ b/src/models/text.rs
@@ -44,7 +44,9 @@ pub struct Annotations {
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct RichTextCommon {
     pub plain_text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub href: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub annotations: Option<Annotations>,
 }
 


### PR DESCRIPTION
Notion API expects `rich_text` instead of `text` while querying the database with property filtering