### PR TITLE
Make all `children` fields `Option`

### DIFF
--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -395,12 +395,12 @@ pub struct TableOfContents {
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct ColumnListFields {
-    pub children: Vec<Block>,
+    pub children: Option<Vec<Block>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct ColumnFields {
-    pub children: Vec<Block>,
+    pub children: Option<Vec<Block>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
@@ -411,7 +411,7 @@ pub struct LinkPreviewFields {
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct TemplateFields {
     pub rich_text: Vec<RichText>,
-    pub children: Vec<Block>,
+    pub children: Option<Vec<Block>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
@@ -430,7 +430,7 @@ pub struct SyncedFromObject {
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct SyncedBlockFields {
     pub synced_from: Option<SyncedFromObject>,
-    pub children: Vec<Block>,
+    pub children: Option<Vec<Block>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
@@ -438,7 +438,7 @@ pub struct TableFields {
     pub table_width: u64,
     pub has_column_header: bool,
     pub has_row_header: bool,
-    pub children: Vec<Block>,
+    pub children: Option<Vec<Block>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]


### PR DESCRIPTION
Hi ! I found bug when using `NotionApi::get_block_children`.

As [the document](https://developers.notion.com/reference/get-block-children) says, children API does not return nested children. Thus, it's possible that returned json doesn't have `children` key for `column_list`, `column`, etc. like this:
<img width="163" alt="スクリーンショット 2023-02-12 5 41 39" src="https://user-images.githubusercontent.com/54735373/218280299-72d7de01-f676-4a89-abb5-b0dd69948a4d.png">

I just added `Option` to the type definition of `children` for each struct.