### PR TITLE
BugFix: wrong key in for `Block::ChildDatabase`

### DIFF
--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -516,7 +516,7 @@ pub enum Block {
     ChildDatabase {
         #[serde(flatten)]
         common: BlockCommon,
-        child_page: ChildDatabaseFields,
+        child_database: ChildDatabaseFields,
     },
     Embed {
         #[serde(flatten)]


### PR DESCRIPTION
Hi, there was wrong key in enum variant `Block::ChildDatabase`.
I fixed it.