### PR TITLE
Add methods for modfifing pages and blocks

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,6 +252,25 @@ impl NotionApi {
         }
     }
 
+    /// Get a block by [BlockId].
+    pub async fn get_block<T: AsIdentifier<BlockId>>(
+        &self,
+        page_id: T,
+    ) -> Result<Block, Error> {
+        let result = self
+            .make_json_request(self.client.get(format!(
+                "https://api.notion.com/v1/blocks/{}",
+                page_id.as_id()
+            )))
+            .await?;
+
+        match result {
+            Object::Block { block } => Ok(block),
+            response => Err(Error::UnexpectedResponse { response }),
+        }
+    }
+
+    /// Get block children a block by [BlockId].
     pub async fn get_block_children<T: AsIdentifier<BlockId>>(
         &self,
         block_id: T,
@@ -269,6 +288,7 @@ impl NotionApi {
         }
     }
 
+    /// Append block children under a block by [BlockId].
     pub async fn append_block_children<P, T>(
         &self,
         block_id: P,
@@ -295,6 +315,7 @@ impl NotionApi {
         }
     }
 
+    /// Delete a block by [BlockId].
     pub async fn delete_block<T: AsIdentifier<BlockId>>(
         &self,
         block_id: T,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -294,4 +294,21 @@ impl NotionApi {
             response => Err(Error::UnexpectedResponse { response }),
         }
     }
+
+    pub async fn delete_block<T: AsIdentifier<BlockId>>(
+        &self,
+        block_id: T,
+    ) -> Result<Block, Error> {
+        let result = self
+            .make_json_request(self.client.delete(&format!(
+                "https://api.notion.com/v1/blocks/{block_id}",
+                block_id = block_id.as_id()
+            )))
+            .await?;
+
+        match result {
+            Object::Block { block } => Ok(block),
+            response => Err(Error::UnexpectedResponse { response }),
+        }
+    }
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -190,6 +190,11 @@ pub struct PageCreateRequest {
     pub children: Option<Vec<CreateBlock>>,
 }
 
+#[derive(Serialize, Debug, Eq, PartialEq, Clone)]
+pub struct UpdateBlockChildrenRequest {
+    pub children: Vec<CreateBlock>,
+}
+
 #[derive(Serialize, Debug, Eq, PartialEq)]
 pub struct PageUpdateRequest {
     pub properties: Properties,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -182,7 +182,7 @@ impl Properties {
     }
 }
 
-#[derive(Serialize, Debug, Eq, PartialEq)]
+#[derive(Serialize, Debug, Eq, PartialEq, Clone)]
 pub struct PageCreateRequest {
     pub parent: Parent,
     pub properties: Properties,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 use crate::ids::{AsIdentifier, DatabaseId, PageId};
-use crate::models::block::{Block, CreateBlock};
+use crate::models::block::{Block, CreateBlock, FileOrEmojiObject};
 use crate::models::error::ErrorResponse;
 use crate::models::paging::PagingCursor;
 use crate::models::users::User;
@@ -188,6 +188,15 @@ pub struct PageCreateRequest {
     pub properties: Properties,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub children: Option<Vec<CreateBlock>>,
+}
+
+#[derive(Serialize, Debug, Eq, PartialEq)]
+pub struct PageUpdateRequest {
+    pub properties: Properties,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub archived: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon: Option<FileOrEmojiObject>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]

--- a/src/models/paging.rs
+++ b/src/models/paging.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Clone)]
 #[serde(transparent)]
-pub struct PagingCursor(String);
+pub struct PagingCursor(pub(crate) String);
 
 #[derive(Serialize, Debug, Eq, PartialEq, Default, Clone)]
 pub struct Paging {

--- a/src/models/search.rs
+++ b/src/models/search.rs
@@ -44,7 +44,7 @@ pub struct Filter {
     value: FilterValue,
 }
 
-#[derive(Serialize, Debug, Eq, PartialEq, Default)]
+#[derive(Serialize, Debug, Eq, PartialEq, Default, Clone)]
 pub struct SearchRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     query: Option<String>,
@@ -54,6 +54,21 @@ pub struct SearchRequest {
     filter: Option<Filter>,
     #[serde(flatten)]
     paging: Option<Paging>,
+}
+
+impl Pageable for SearchRequest {
+    fn start_from(
+        self,
+        starting_point: Option<PagingCursor>,
+    ) -> Self {
+        SearchRequest {
+            paging: Some(Paging {
+                start_cursor: starting_point,
+                page_size: self.paging.and_then(|p| p.page_size),
+            }),
+            ..self
+        }
+    }
 }
 
 #[derive(Serialize, Debug, Eq, PartialEq, Clone)]
@@ -318,7 +333,7 @@ impl Pageable for DatabaseQuery {
     }
 }
 
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub enum NotionSearch {
     /// When supplied, limits which pages are returned by comparing the query to the page title.
     Query(String),

--- a/src/models/text.rs
+++ b/src/models/text.rs
@@ -29,7 +29,7 @@ pub enum TextColor {
 
 /// Rich text annotations
 /// See <https://developers.notion.com/reference/rich-text#annotations>
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Default)]
 pub struct Annotations {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bold: Option<bool>,
@@ -47,7 +47,7 @@ pub struct Annotations {
 
 /// Properties common on all rich text objects
 /// See <https://developers.notion.com/reference/rich-text#all-rich-text>
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Default)]
 pub struct RichTextCommon {
     pub plain_text: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -61,7 +61,7 @@ pub struct Link {
     pub url: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone, Default)]
 pub struct Text {
     pub content: String,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/models/text.rs
+++ b/src/models/text.rs
@@ -31,11 +31,17 @@ pub enum TextColor {
 /// See <https://developers.notion.com/reference/rich-text#annotations>
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct Annotations {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bold: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub code: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub color: Option<TextColor>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub italic: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub strikethrough: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub underline: Option<bool>,
 }
 
@@ -58,6 +64,7 @@ pub struct Link {
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct Text {
     pub content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub link: Option<Link>,
 }
 

--- a/src/models/users.rs
+++ b/src/models/users.rs
@@ -4,7 +4,9 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq)]
 pub struct UserCommon {
     pub id: UserId,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub avatar_url: Option<String>,
 }
 


### PR DESCRIPTION
Hey!

This is a larger PR because it wasn't originally meant to be a single PR. I was trying to use your library for something and I couldn't figure out how to modify things so I forked it and ended up making multiple changes. 

Together thought they effectively add an API for modifying pages and blocks which as far as I could tell originally wansn't possible. So they might make sense as a signgle PR. 

Let me know what you think. If you like all of it I am happy to do some changes, add tests,... whatever else. But if you think only some subsets of this PR should be considered please let me know and I am happy to break it up into separate PRs.

Individual things done:
 * Add `update_page` to update contents of an existing page
 * Add `get_block` get block by block id (which can be a page id as pages are also blocks as far as contents are concerned?)
 * Add `get_block_children_with_cursor` which lets you iterate over children of a block. I wans't sure how to use the existing cursor to iterate without this
 * Add `append_block_children` which allows user to attach more block under a block or a page
 * Add `delete_block` which is pretty self explanatory 
 * Add `update_block` which is useful for doing things like changing text content or status of a checkbox but can't do things like change block types
 * Implement `Pageable ` for `SearchRequest ` because I couldn't figure out how to page over results of a serach for pages
 
 Lastly I also changed some API types by adding `skip_serializing_if ` on None, Default, or Clone. This was all just to make working with them easier and because I think we were generating json that notion wasn't happy in some cases.
 
 Thanks!